### PR TITLE
 Update schemas to depend on a single source of truth 

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -11,6 +11,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  HUSKY: 0
+
 jobs:
   # Build job
   build:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm run ci || (printf "\n\e[31m%s\e[0m\n" "failed CI, to skip this check, push with --no-verify" >&2 && exit 1)

--- a/app/api/farms/route.ts
+++ b/app/api/farms/route.ts
@@ -1,9 +1,9 @@
 import {
   CreateFarmResponse,
-  createFarmRequest,
+  createFarmRequestSchema,
   DeleteFarmResponse,
-  deleteFarmRequest,
-} from '@/lib/api/farms/schema';
+  deleteFarmRequestSchema,
+} from '@/lib/api/farms';
 import { auth } from '@/lib/auth/server';
 import { createFarm, deleteFarm } from '@/lib/db/data/farms';
 import { NextResponse } from 'next/server';
@@ -27,7 +27,7 @@ export async function POST(
 
     // Parse the request body
     const body = await request.json();
-    const result = createFarmRequest.safeParse(body);
+    const result = createFarmRequestSchema.safeParse(body);
     if (!result.success) {
       return NextResponse.json<CreateFarmResponse>(
         { success: false, error: z.prettifyError(result.error) },
@@ -64,7 +64,7 @@ export async function DELETE(request: Request) {
 
     // Parse the request body
     const body = await request.json();
-    const result = deleteFarmRequest.safeParse(body);
+    const result = deleteFarmRequestSchema.safeParse(body);
     if (!result.success) {
       return NextResponse.json<DeleteFarmResponse>(
         { success: false, error: z.prettifyError(result.error) },

--- a/app/farms/page.tsx
+++ b/app/farms/page.tsx
@@ -1,6 +1,6 @@
 import { FarmList } from '@/components/farms/FarmList';
 import { auth } from '@/lib/auth/server';
-import { listUserFarms } from '@/lib/db/data/farms';
+import { listUserFarms } from '@/lib/db/data/farms/queries';
 import { headers } from 'next/headers';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';

--- a/components/farms/FarmItem.tsx
+++ b/components/farms/FarmItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Farm } from '@/lib/db/data/types';
+import { Farm } from '@/lib/db/data/farms';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Trash2 } from 'lucide-react';

--- a/components/farms/FarmList.tsx
+++ b/components/farms/FarmList.tsx
@@ -1,4 +1,4 @@
-import { Farm } from '@/lib/db/data/types';
+import { Farm } from '@/lib/db/data/farms';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import Link from 'next/link';

--- a/components/farms/useCreateFarm.ts
+++ b/components/farms/useCreateFarm.ts
@@ -4,15 +4,15 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   CreateFarmRequest,
-  createFarmResponse,
-  createFarmRequest,
+  createFarmResponseSchema,
+  createFarmRequestSchema,
 } from '@/lib/api/farms/schema';
 
 export function useCreateFarm() {
   const router = useRouter();
   const form = useForm({
     defaultValues: { name: '', description: '' },
-    resolver: zodResolver(createFarmRequest),
+    resolver: zodResolver(createFarmRequestSchema),
   });
 
   const [loading, setLoading] = useState(false);
@@ -31,7 +31,7 @@ export function useCreateFarm() {
       if (!res.ok) {
         throw new Error('Failed to create farm');
       }
-      const response = createFarmResponse.safeParse(await res.json());
+      const response = createFarmResponseSchema.safeParse(await res.json());
       if (!response.success) {
         throw new Error('Invalid response from server');
       } else if (!response.data.success) {

--- a/lib/api/farms/index.ts
+++ b/lib/api/farms/index.ts
@@ -1,0 +1,1 @@
+export * from './schema';

--- a/lib/api/farms/schema.ts
+++ b/lib/api/farms/schema.ts
@@ -1,53 +1,39 @@
 import { z } from 'zod';
-import { farm } from '@/lib/db/schema/farm';
+import { Farm, farmSchema, insertFarmSchema } from '@/lib/db/data/farms';
+
+const baseSuccessSchema = z.object({
+  success: z.literal(true),
+});
+const baseFailureSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+});
 
 // Create Farm Schemas and Types
-export const createFarmRequest = z.object({
-  name: z
-    .string()
-    .min(1, 'Farm name is required')
-    .max(100, 'Farm name must be less than 100 characters'),
-  description: z.string().default(''),
-}) satisfies z.ZodType<typeof farm.$inferInsert>;
+export const createFarmRequestSchema = insertFarmSchema;
 
-const createFarmSuccess = z.object({
-  success: z.literal(true),
-  id: z.number(),
-  name: z.string(),
-  createdAt: z.date(),
-});
+const createFarmSuccessSchema = z.object({
+  ...farmSchema.shape,
+  ...baseSuccessSchema.shape,
+}) satisfies z.ZodType<Farm>;
 
-const createFarmFailure = z.object({
-  success: z.literal(false),
-  error: z.string(),
-});
-
-export const createFarmResponse = z.union([
-  createFarmSuccess,
-  createFarmFailure,
+export const createFarmResponseSchema = z.union([
+  createFarmSuccessSchema,
+  baseFailureSchema,
 ]);
 
-export type CreateFarmRequest = z.infer<typeof createFarmRequest>;
-export type CreateFarmResponse = z.infer<typeof createFarmResponse>;
+export type CreateFarmRequest = z.infer<typeof createFarmRequestSchema>;
+export type CreateFarmResponse = z.infer<typeof createFarmResponseSchema>;
 
 // Delete Farm Schemas and Types
-export const deleteFarmRequest = z.object({
-  id: z.number(),
+export const deleteFarmRequestSchema = farmSchema.pick({
+  id: true,
 });
 
-const deleteFarmSuccess = z.object({
-  success: z.literal(true),
-});
-
-const deleteFarmFailure = z.object({
-  success: z.literal(false),
-  error: z.string(),
-});
-
-export const deleteFarmResponse = z.union([
-  deleteFarmSuccess,
-  deleteFarmFailure,
+export const deleteFarmResponseSchema = z.union([
+  baseSuccessSchema,
+  baseFailureSchema,
 ]);
 
-export type DeleteFarmRequest = z.infer<typeof deleteFarmRequest>;
-export type DeleteFarmResponse = z.infer<typeof deleteFarmResponse>;
+export type DeleteFarmRequest = z.infer<typeof deleteFarmRequestSchema>;
+export type DeleteFarmResponse = z.infer<typeof deleteFarmResponseSchema>;

--- a/lib/db/data/farms/index.ts
+++ b/lib/db/data/farms/index.ts
@@ -1,0 +1,2 @@
+export * from './queries';
+export * from './schema';

--- a/lib/db/data/farms/queries.ts
+++ b/lib/db/data/farms/queries.ts
@@ -1,8 +1,8 @@
 import { db } from '@/lib/db';
 import { eq } from 'drizzle-orm';
-import { farmUser } from '../schema/farmUser';
-import { farm } from '../schema/farm';
-import { Farm } from './types';
+import { farmUser } from '../../schema/farmUser';
+import { farm } from '../../schema/farm';
+import { Farm, InsertFarm } from './schema';
 
 export const listUserFarms = async (userId: string): Promise<Farm[]> => {
   const res = await db.query.farm.findMany({
@@ -23,11 +23,11 @@ export const listUserFarms = async (userId: string): Promise<Farm[]> => {
 
 export const createFarm = async (
   userId: string,
-  farmInsert: typeof farm.$inferInsert,
+  insertFarm: InsertFarm,
 ): Promise<Farm> => {
   return await db.transaction(async (tx) => {
     // Create the farm
-    const [newFarm] = await tx.insert(farm).values(farmInsert).returning();
+    const [newFarm] = await tx.insert(farm).values(insertFarm).returning();
 
     // Add the user as a farmer to the farm
     await tx.insert(farmUser).values({

--- a/lib/db/data/farms/schema.ts
+++ b/lib/db/data/farms/schema.ts
@@ -1,0 +1,22 @@
+import z from 'zod';
+import { farm } from '../../schema/farm';
+import { timestamps } from '../../schema';
+
+export const farmSchema = z.object({
+  id: z.number(),
+  name: z
+    .string()
+    .min(1, 'Farm name is required')
+    .max(100, 'Farm name must be less than 100 characters'),
+  description: z.string(),
+  createdAt: z.date(),
+}) satisfies z.ZodType<
+  Omit<typeof farm.$inferSelect, 'updatedAt' | 'deletedAt'>
+>;
+
+export const insertFarmSchema = farmSchema.omit({ id: true }).partial({
+  description: true,
+}) satisfies z.ZodType<Omit<typeof farm.$inferInsert, keyof typeof timestamps>>;
+
+export type Farm = z.infer<typeof farmSchema>;
+export type InsertFarm = z.infer<typeof insertFarmSchema>;

--- a/lib/db/data/types.ts
+++ b/lib/db/data/types.ts
@@ -1,3 +1,0 @@
-import { farm } from '../schema/farm';
-
-export type Farm = Omit<typeof farm.$inferSelect, 'updatedAt' | 'deletedAt'>;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "next start",
     "test": "jest",
     "tsc": "next typegen && tsc --noEmit",
-    "ci": "pnpm run lint && pnpm run tsc && pnpm run test"
+    "ci": "pnpm run lint && pnpm run tsc && pnpm run test",
+    "prepare": "husky"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
@@ -60,6 +61,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "globals": "^16.3.0",
+    "husky": "^9.1.7",
     "jest": "^30.1.3",
     "jest-environment-jsdom": "^30.1.2",
     "prettier": "^3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       globals:
         specifier: ^16.3.0
         version: 16.3.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       jest:
         specifier: ^30.1.3
         version: 30.1.3(@types/node@20.19.11)(esbuild-register@3.6.0(esbuild@0.25.9))(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
@@ -2865,6 +2868,11 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -7462,6 +7470,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  husky@9.1.7: {}
 
   iconv-lite@0.6.3:
     dependencies:


### PR DESCRIPTION
This pull request refactors the farm-related API and data layers to use consistent Zod schemas and centralizes farm type definitions. It also introduces Husky for Git hooks and updates the CI workflow and dependencies. The changes improve type safety, maintainability, and developer workflow.